### PR TITLE
Fix body reading and introduce Blink.await helper

### DIFF
--- a/blink/blink.ml
+++ b/blink/blink.ml
@@ -27,8 +27,8 @@ let request = Connection.request
 let stream = Connection.stream
 let messages = Connection.messages
 
-let await conn =
+let await ?on_message conn =
   let ( let* ) = Result.bind in
-  let* conn, messages = messages conn in
+  let* conn, messages = messages ?on_message conn in
   let res, body = Msg.to_response messages in
   Ok (conn, res, body)

--- a/blink/blink.ml
+++ b/blink/blink.ml
@@ -27,8 +27,8 @@ let request = Connection.request
 let stream = Connection.stream
 let messages = Connection.messages
 
-let await conn = 
-  let (let*) = Result.bind in
+let await conn =
+  let ( let* ) = Result.bind in
   let* conn, messages = messages conn in
   let res, body = Msg.to_response messages in
   Ok (conn, res, body)

--- a/blink/blink.ml
+++ b/blink/blink.ml
@@ -25,3 +25,10 @@ let connect uri =
 
 let request = Connection.request
 let stream = Connection.stream
+let messages = Connection.messages
+
+let await conn = 
+  let (let*) = Result.bind in
+  let* conn, messages = messages conn in
+  let res, body = Msg.to_response messages in
+  Ok (conn, res, body)

--- a/blink/blink.mli
+++ b/blink/blink.mli
@@ -56,6 +56,7 @@ val stream :
 *)
 
 val messages :
+  ?on_message:(Connection.message list -> unit) ->
   Connection.t ->
   ( Connection.t * Connection.message list,
     [> `Closed
@@ -67,9 +68,13 @@ val messages :
 (**
    [messages conn] will stream and collect all messages coming in from a
    connection. This is handy if you want to consume messages in batches.
+
+   The [on_message] hook can be used to tap into the collection and report
+   progress.
 *)
 
 val await :
+  ?on_message:(Connection.message list -> unit) ->
   Connection.t ->
   ( Connection.t * Http.Response.t * Bytestring.t,
     [> `Closed
@@ -85,6 +90,9 @@ val await :
    Useful for one-off request/response cycles.
 
    For stream processing of body responses see [stream conn].
+
+   The [on_message] hook can be used to tap into the collection and report
+   progress.
 *)
 
 module WebSocket : sig

--- a/blink/blink.mli
+++ b/blink/blink.mli
@@ -39,12 +39,6 @@ val request :
   unit ->
   (Connection.t, [> `Closed | `Unix_error of Unix.error ]) IO.io_result
 
-(**
-   [stream conn] is a low-level API that returns a list of messages streamed
-   from the connection and a handler to the updated connection.
-
-   You can use this to process data as it comes
-*)
 val stream :
   Connection.t ->
   ( Connection.t * Connection.message list,
@@ -54,11 +48,13 @@ val stream :
     | `Excess_body_read
     | `Unix_error of Unix.error ] )
   IO.io_result
-
 (**
-   [messages conn] will stream and collect all messages coming in from a
-   connection. This is handy if you want to consume messages in batches.
+   [stream conn] is a low-level API that returns a list of messages streamed
+   from the connection and a handler to the updated connection.
+
+   You can use this to process data as it comes
 *)
+
 val messages :
   Connection.t ->
   ( Connection.t * Connection.message list,
@@ -68,7 +64,20 @@ val messages :
     | `Excess_body_read
     | `Unix_error of Unix.error ] )
   IO.io_result
+(**
+   [messages conn] will stream and collect all messages coming in from a
+   connection. This is handy if you want to consume messages in batches.
+*)
 
+val await :
+  Connection.t ->
+  ( Connection.t * Http.Response.t * Bytestring.t,
+    [> `Closed
+    | `Eof
+    | `Response_parsing_error
+    | `Excess_body_read
+    | `Unix_error of Unix.error ] )
+  IO.io_result
 (**
    [await conn] will stream the connection until it is drained, collect the
    body, and build a response object.
@@ -77,14 +86,6 @@ val messages :
 
    For stream processing of body responses see [stream conn].
 *)
-val await : Connection.t -> 
-  ( Connection.t * Http.Response.t * Bytestring.t,
-    [> `Closed
-    | `Eof
-    | `Response_parsing_error
-    | `Excess_body_read
-    | `Unix_error of Unix.error ] )
-  IO.io_result
 
 module WebSocket : sig
   type t

--- a/blink/blink.mli
+++ b/blink/blink.mli
@@ -1,5 +1,7 @@
 (** {1 Blink}
 
+Blink is a low-level, functional client for HTTP and WebSockets.
+
 *)
 
 open Riot
@@ -37,9 +39,46 @@ val request :
   unit ->
   (Connection.t, [> `Closed | `Unix_error of Unix.error ]) IO.io_result
 
+(**
+   [stream conn] is a low-level API that returns a list of messages streamed
+   from the connection and a handler to the updated connection.
+
+   You can use this to process data as it comes
+*)
 val stream :
   Connection.t ->
   ( Connection.t * Connection.message list,
+    [> `Closed
+    | `Eof
+    | `Response_parsing_error
+    | `Excess_body_read
+    | `Unix_error of Unix.error ] )
+  IO.io_result
+
+(**
+   [messages conn] will stream and collect all messages coming in from a
+   connection. This is handy if you want to consume messages in batches.
+*)
+val messages :
+  Connection.t ->
+  ( Connection.t * Connection.message list,
+    [> `Closed
+    | `Eof
+    | `Response_parsing_error
+    | `Excess_body_read
+    | `Unix_error of Unix.error ] )
+  IO.io_result
+
+(**
+   [await conn] will stream the connection until it is drained, collect the
+   body, and build a response object.
+
+   Useful for one-off request/response cycles.
+
+   For stream processing of body responses see [stream conn].
+*)
+val await : Connection.t -> 
+  ( Connection.t * Http.Response.t * Bytestring.t,
     [> `Closed
     | `Eof
     | `Response_parsing_error

--- a/blink/connection.ml
+++ b/blink/connection.ml
@@ -167,12 +167,14 @@ let stream (Conn ({ headers; reader; state; protocol; _ } as conn)) =
             ( Conn { conn with state = More { body_remaining; body_prefix } },
               [ `Data body ] ))
 
-let messages conn =
+let messages ?(on_message = fun _ -> ()) conn =
   let rec consume_stream conn messages =
     let* conn, msgs = stream conn in
+    on_message msgs;
     match msgs with
     | [] | [ `Done ] | `Done :: _ -> Ok (conn, List.rev msgs @ messages)
-    | _ -> consume_stream conn (List.rev msgs @ messages)
+    | _ -> 
+        consume_stream conn (List.rev msgs @ messages)
   in
   let* conn, messages = consume_stream conn [] in
   let messages = List.rev messages in

--- a/blink/connection.ml
+++ b/blink/connection.ml
@@ -6,12 +6,25 @@ end)
 
 let ( let* ) = Result.bind
 
+let pp_err fmt (err : [ IO.io_error | `Excess_body_read ]) =
+  match err with
+  | `Excess_body_read -> Format.fprintf fmt "Excess_body_read"
+  | #IO.io_error as err -> IO.pp_err fmt err
+
 type message = Msg.message
+type measure = [ `unknown | `fixed of int ]
+
+let pp_measure fmt m =
+  match m with
+  | `unknown -> Format.fprintf fmt "unknown"
+  | `fixed size -> Format.fprintf fmt "%d" size
+
+let measure_to_int m = match m with `unknown -> 0 | `fixed size -> size
 
 type state =
   | Done
   | Unread
-  | More of { body_remaining : int; prefix : Bytestring.t }
+  | More of { body_remaining : measure; body_prefix : Bytestring.t }
 
 type t =
   | Conn : {
@@ -57,60 +70,113 @@ let request (Conn conn) req ?body () =
   let* () = IO.write_all conn.writer ~buf:(Bytestring.to_string buf) in
   Ok (Conn conn)
 
-let stream (Conn conn) =
-  let (module Protocol : Protocol.Intf) = conn.protocol in
-  match conn.state with
-  | Unread ->
-      let* status, headers, prefix =
-        Protocol.Response.read_header conn.reader
-      in
-      let body_remaining =
-        let content_length =
-          Http.Header.get_content_range headers
-          |> Option.value ~default:0L |> Int64.to_int
-        in
-        debug (fun f ->
-            f "just read prefix=%d out of %d" (Bytestring.length prefix)
-              content_length);
-        if content_length > 0 then content_length - Bytestring.length prefix
-        else 0
-      in
-
-      let parts = [ `Status status; `Headers headers ] in
-
-      Ok
-        ( Conn
-            {
-              conn with
-              status;
-              headers;
-              state = More { prefix; body_remaining };
-            },
-          parts )
-  | More { body_remaining; prefix } -> (
-      debug (fun f ->
-          f "streaming more body_remaining=%d prefix=%a" body_remaining
-            Bytestring.pp prefix);
-      match
-        Protocol.Response.read_body ~prefix ~headers:conn.headers
-          ~body_remaining conn.reader
-      with
-      | `Error reason -> Error reason
-      | `Ok [] -> Ok (Conn { conn with state = Done }, [ `Done ])
-      | `Ok parts ->
-          let parts = List.map (fun p -> `Data p) parts in
-          Ok (Conn { conn with state = Done }, parts)
-      | `More (parts, prefix, body_remaining) ->
-          let parts = List.map (fun p -> `Data p) parts in
-          Ok (Conn { conn with state = More { body_remaining; prefix } }, parts)
-      )
+let stream (Conn ({ headers; reader; state; protocol; _ } as conn)) =
+  let (module Protocol : Protocol.Intf) = protocol in
+  match state with
   | Done -> Ok (Conn conn, [ `Done ])
+  (*
+      NOTE(@leostera): when we start streaming on a connection, the first things
+      we want to get out of it are going to be the status and the header. This will
+      give us more information about how to read the body, if there's a body at all.
+
+      However, sometimes when we read the first chunks of data sent to us, we also
+      find a portion of the body itself. We call this the `body_prefix`.
+
+      At this point we can emit the `` `Status `` and `` `Header `` messages,
+      and if the remaining body (`body_remaining`) is not zero, then we save the
+      `body_prefix` for the next call of `stream conn`.
+
+      When the `body_remaining` is zero, then we have read the entire length of
+      the body, and we can return the `` `Data `` and `` `Done `` messages as
+      well.
+  *)
+  | Unread ->
+      debug (fun f -> f "Beginning stream on unread connection...");
+      let* status, headers, body_prefix =
+        Protocol.Response.read_header reader
+      in
+      debug (fun f -> f "-> status: %a" Http.Status.pp status);
+      debug (fun f ->
+          f "-> body prefix size: %d" (Bytestring.length body_prefix));
+      let content_length =
+        match Http.Header.get_content_range headers with
+        | None -> `unknown
+        | Some size -> `fixed (Int64.to_int size)
+      in
+      debug (fun f ->
+          f "-> expected content length: %a" pp_measure content_length);
+      let body_remaining =
+        match content_length with
+        | `unknown | `fixed 0 -> content_length
+        | `fixed size -> `fixed (size - Bytestring.length body_prefix)
+      in
+      debug (fun f -> f "-> remaining body: %a" pp_measure body_remaining);
+
+      let messages = [ `Status status; `Headers headers ] in
+
+      let state, messages =
+        match body_remaining with
+        (* when we know we've read the entire body, we finish the streaming *)
+        | `fixed 0 -> (Done, messages @ [ `Data body_prefix; `Done ])
+        (* we the length is unknown, or there is more body to read, we continue streaming *)
+        | `fixed _ | `unknown -> (More { body_remaining; body_prefix }, messages)
+      in
+
+      Ok (Conn { conn with status; headers; state }, messages)
+  (*
+      NOTE(@leostera): when we poll on the connection to read more of the body,
+      we either know exactly how much body is remaining, or we're it is unknown
+      (for streaming large bodies this is common).
+
+      If the remaining is zero, we mark the stream as completed, and return the
+      `` `Done `` message.
+
+      If the remaining is larger than zero, or it is unknown, we will attempt
+      to read more of the body.
+
+      The result from reading can be either an error, an indication that we
+      have reached the end of the stream, or that we should continue reading.
+  *)
+  | More { body_remaining = `fixed 0; _ } ->
+      Ok (Conn { conn with state = Done }, [ `Done ])
+  | More { body_remaining; body_prefix } -> (
+      debug (fun f -> f "Continuing stream on connection...");
+      debug (fun f -> f "-> body_remaining: %a" pp_measure body_remaining);
+      match
+        let body_remaining = measure_to_int body_remaining in
+        Protocol.Response.read_body ~buffer:body_prefix ~headers ~body_remaining
+          reader
+      with
+      | `error reason ->
+          error (fun f -> f "stream error: %a" pp_err reason);
+          Error reason
+      | `finished part ->
+          let msgs =
+            if Bytestring.length part = 0 then [ `Done ]
+            else [ `Data part; `Done ]
+          in
+          Ok (Conn { conn with state = Done }, msgs)
+      | `continue (body, body_prefix) ->
+          let body_remaining =
+            match body_remaining with
+            | `unknown -> `unknown
+            | `fixed total ->
+                `fixed Bytestring.(total - length body - length body_prefix)
+          in
+          Ok
+            ( Conn { conn with state = More { body_remaining; body_prefix } },
+              [ `Data body ] ))
 
 let messages conn =
   let rec consume_stream conn messages =
     let* conn, msgs = stream conn in
     match msgs with
-    | [ `Done ] -> Ok (List.rev messages)
-    | _ -> consume_stream conn (msgs @ messages)
+    | [] | [ `Done ] | `Done :: _ -> Ok (conn, List.rev msgs @ messages)
+    | _ -> consume_stream conn (List.rev msgs @ messages)
   in
-  consume_stream conn []
+  let* conn, messages = consume_stream conn [] in
+  let messages = List.rev messages in
+  debug (fun f ->
+      f "collected %d messages:\n%a" (List.length messages) Msg.pp_messages
+        messages);
+  Ok (conn, messages)

--- a/blink/http1.ml
+++ b/blink/http1.ml
@@ -79,10 +79,6 @@ module Response = struct
         debug (fun f -> f "read_chunked_body: last chunk!");
         Ok `no_more_chunks
     | [ chunk_size; chunk_data ] -> (
-        debug (fun f ->
-            f "[%S;%S]"
-              (Bytestring.to_string chunk_size)
-              (Bytestring.to_string chunk_data));
         let chunk_size =
           Int64.(of_string ("0x" ^ Bytestring.to_string chunk_size) |> to_int)
         in

--- a/blink/http1.ml
+++ b/blink/http1.ml
@@ -55,7 +55,8 @@ module Response = struct
         debug (fun f -> f "reading chunked body");
         match read_chunked_body ~buffer:prefix reader with
         | Ok (body, buffer) when Bytestring.is_empty buffer ->
-            debug (fun f -> f "read chunked_body: ok");
+            debug (fun f ->
+                f "read chunked_body: ok (%d bytes)" (Bytestring.length body));
             `Ok (if Bytestring.is_empty body then [] else [ body ])
         | Ok (body, buffer) ->
             debug (fun f -> f "read chunked_body: more");

--- a/blink/http2.ml
+++ b/blink/http2.ml
@@ -6,5 +6,5 @@ end
 
 module Response = struct
   let read_header _reader = Ok (`OK, Http.Header.of_list [], Bytestring.empty)
-  let read_body ~prefix:_ ~headers:_ ~body_remaining:_ _reader = `Ok []
+  let read_body ~buffer:_ ~headers:_ ~body_remaining:_ _reader = `finished Bytestring.empty
 end

--- a/blink/http2.ml
+++ b/blink/http2.ml
@@ -6,5 +6,7 @@ end
 
 module Response = struct
   let read_header _reader = Ok (`OK, Http.Header.of_list [], Bytestring.empty)
-  let read_body ~buffer:_ ~headers:_ ~body_remaining:_ _reader = `finished Bytestring.empty
+
+  let read_body ~buffer:_ ~headers:_ ~body_remaining:_ _reader =
+    `finished Bytestring.empty
 end

--- a/blink/msg.ml
+++ b/blink/msg.ml
@@ -10,8 +10,25 @@ let pp fmt (t : message) =
   match t with
   | `Headers hs -> Format.fprintf fmt "Headers(%a)" Http.Header.pp_hum hs
   | `Done -> Format.fprintf fmt "Done"
-  | `Data bs -> Format.fprintf fmt "Data(%S)" (Bytestring.to_string bs)
+  | `Data bs -> Format.fprintf fmt "Data(%d bytes)" (Bytestring.length bs)
   | `Status s -> Format.fprintf fmt "Status(%a)" Http.Status.pp s
 
 let pp_messages fmt (t : message list) =
-  Format.pp_print_list ~pp_sep:(fun fmt () -> Format.fprintf fmt "; ") pp fmt t
+  Format.fprintf fmt "[\n  ";
+  Format.pp_print_list ~pp_sep:(fun fmt () -> Format.fprintf fmt ";\n  ") pp fmt t;
+  Format.fprintf fmt "\n]"
+
+let to_response messages =
+  let status, headers, body =
+    messages |>
+    List.fold_left (fun ((status, headers, body) as acc) msg ->
+      match msg with
+      | `Status s -> (Some s, headers, body)
+      | `Headers hs -> (status, Some hs, body)
+      | `Data data -> (status, headers, Bytestring.(body ^ data))
+      | `Done -> acc
+    ) (None, None, Bytestring.empty)
+  in
+  Http.Response.make ?status ?headers (), body
+
+  

--- a/blink/msg.ml
+++ b/blink/msg.ml
@@ -15,20 +15,21 @@ let pp fmt (t : message) =
 
 let pp_messages fmt (t : message list) =
   Format.fprintf fmt "[\n  ";
-  Format.pp_print_list ~pp_sep:(fun fmt () -> Format.fprintf fmt ";\n  ") pp fmt t;
+  Format.pp_print_list
+    ~pp_sep:(fun fmt () -> Format.fprintf fmt ";\n  ")
+    pp fmt t;
   Format.fprintf fmt "\n]"
 
 let to_response messages =
   let status, headers, body =
-    messages |>
-    List.fold_left (fun ((status, headers, body) as acc) msg ->
-      match msg with
-      | `Status s -> (Some s, headers, body)
-      | `Headers hs -> (status, Some hs, body)
-      | `Data data -> (status, headers, Bytestring.(body ^ data))
-      | `Done -> acc
-    ) (None, None, Bytestring.empty)
+    messages
+    |> List.fold_left
+         (fun ((status, headers, body) as acc) msg ->
+           match msg with
+           | `Status s -> (Some s, headers, body)
+           | `Headers hs -> (status, Some hs, body)
+           | `Data data -> (status, headers, Bytestring.(body ^ data))
+           | `Done -> acc)
+         (None, None, Bytestring.empty)
   in
-  Http.Response.make ?status ?headers (), body
-
-  
+  (Http.Response.make ?status ?headers (), body)

--- a/blink/protocol.ml
+++ b/blink/protocol.ml
@@ -15,11 +15,11 @@ module type Intf = sig
       IO.io_result
 
     val read_body :
-      prefix:Bytestring.t ->
+      buffer:Bytestring.t ->
       headers:Http.Header.t ->
       body_remaining:int ->
       'a IO.Reader.t ->
-      [> `Error of
+      [> `error of
          [> `Closed
          | `Connection_closed
          | `Eof
@@ -31,8 +31,8 @@ module type Intf = sig
          | `Timeout
          | `Unix_error of Unix.error
          | `Would_block ]
-      | `More of Bytestring.t list * Bytestring.t * int
-      | `Ok of Bytestring.t list ]
+      | `continue of Bytestring.t * Bytestring.t
+      | `finished of Bytestring.t ]
   end
 end
 

--- a/blink/websocket.ml
+++ b/blink/websocket.ml
@@ -43,7 +43,7 @@ let upgrade conn path =
     Http.Request.make ~headers ~meth:`GET path
   in
   let* conn = Connection.request conn req () in
-  let* messages = Connection.messages conn in
+  let* conn, messages = Connection.messages conn in
 
   match messages with
   | [ `Headers headers; `Status `Switching_protocols; `Data _ ] ->

--- a/test/blink_stream_test.ml
+++ b/test/blink_stream_test.ml
@@ -7,15 +7,13 @@ open Riot
 let () =
   Riot.run @@ fun () ->
   let _ = Logger.start () in
-  Logger.set_log_level (Some Info);
+  Logger.set_log_level (Some Debug);
   let run () =
     let open Stdlib.Result in
     let* conn = Blink.connect @@ Uri.of_string "https://api.scryfall.com" in
     let req = Http.Request.make "/sets/eld" in
     let* conn = Blink.request conn req () in
-    let* conn, [ _; _ ] = Blink.stream conn in
-    let* conn, [ `Data body ] = Blink.stream conn in
-    let* _conn, [ `Done ] = Blink.stream conn in
+    let* _, _, body = Blink.await conn in
     let str = Bytestring.to_string body in
     Format.printf "%s\n%!" str;
     Ok ()

--- a/test/get_ocaml_org_test.ml
+++ b/test/get_ocaml_org_test.ml
@@ -19,20 +19,18 @@ let req = Http.Request.make "/" in
 let* conn = Blink.request conn req () in
 (* $MDX part-end *)
 (* $MDX part-begin=stream *)
-let* conn, [ `Status status; `Headers headers ] = Blink.stream conn in
-let* conn, [ `Data body ] = Blink.stream conn in
-let* _conn, [ `Done ] = Blink.stream conn in
+let* _conn, response, body = Blink.await conn in
 (* $MDX part-end *)
-match (status, Http.Header.to_list headers, Bytestring.length body) with
-| `OK, _, 32768 ->
+match (response.status, Http.Header.to_list response.headers, Bytestring.length body) with
+| `OK, _, 74428 ->
     Logger.info (fun f -> f "get_ocaml_org_test: OK");
     sleep 0.1;
     Ok (shutdown ())
 | _ ->
     Logger.error (fun f ->
         f "> Got response:\n%s\n%s\n%d\n%!"
-          (Http.Status.to_string status)
-          (Http.Header.to_lines headers |> String.concat "")
+          (Http.Status.to_string response.status)
+          (Http.Header.to_lines response.headers |> String.concat "")
           (Bytestring.length body));
     (* Logger.error (fun f -> f "%a" Bytestring.pp body); *)
     sleep 0.1;

--- a/test/get_ocaml_org_test.ml
+++ b/test/get_ocaml_org_test.ml
@@ -21,7 +21,9 @@ let* conn = Blink.request conn req () in
 (* $MDX part-begin=stream *)
 let* _conn, response, body = Blink.await conn in
 (* $MDX part-end *)
-match (response.status, Http.Header.to_list response.headers, Bytestring.length body) with
+match
+  (response.status, Http.Header.to_list response.headers, Bytestring.length body)
+with
 | `OK, _, 74428 ->
     Logger.info (fun f -> f "get_ocaml_org_test: OK");
     sleep 0.1;


### PR DESCRIPTION
This fixes a bug with the body streaming where in some cases the preread body would not be part of the responses.

It also makes the Connection.stream function a lot easier to think about by introducing the notion of unknown vs fixed body lengths, and documents things up nicely for the two possible branches.

On top I'm adding 2 new helper functions for handling the stream of messages:
* `messages conn` to return all the messages in order by draining the stream
* `await conn` to build an `Http.Response.t` and concatenate the response body (if any)

The later is quite convenient for tests and workloads where you don't need to stream-process the chunks as they come, which I expect to be very common.